### PR TITLE
Use environment variables for tool paths instead of hardcoded

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,13 +32,13 @@ USR_FILES_DIR	:= usr/file
 KERNEL_PATH		:= /sys/kernel.elf
 
 # Compiler settings
-CC      := gcc
+CC      ?= gcc
 CFLAGS  := -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/libc -m32 -nostdlib -nostdinc -fno-builtin -fno-pic -static -ffreestanding -no-pie -Wall -Wextra -Werror -ggdb
 
 AS      := nasm
 ASFLAGS := -f elf32 -g -F dwarf
 
-LD      := ld
+LD      ?= ld
 LDFLAGS := -m elf_i386 -nostdlib -L$(shell dirname $(LIBC_BIN)) -l$(patsubst lib%.a,%,$(shell basename $(LIBC_BIN)))
 KRNL_LD_SCRIPT := auto/kernel.ld
 

--- a/makefile
+++ b/makefile
@@ -92,6 +92,7 @@ $(FS_LAYOUT): $(USR_PRGS) $(USR_FILES_DIR) $(KRNL_BIN)
 
 # Build the file system
 $(FS_IMG): $(KRNL_BIN) $(BOOT_BIN)
+	mkdir -p $(USR_FILES_DIR) 
 	cp -r $(USR_FILES_DIR) ${FS_LAYOUT}
 
 	for prog in $(USR_PRGS); do \

--- a/src/boot/makefile
+++ b/src/boot/makefile
@@ -4,7 +4,8 @@
 # Note that [INC_DIR], [BIN_DIR], [BOOT_BIN] and [BOOT_BIN_DIR] are passed by the parent makefile
 
 # Constants
-CC 	   := gcc
+CC 	   ?= gcc
+LD    ?= ld
 CFLAGS := -I$(INC_DIR) -I$(INC_DIR)/libc -m32 -nostdlib -nostdinc -fno-builtin -fno-pic -static -ffreestanding -no-pie -Wall -Wextra -Werror -ggdb -Og
 BOOTMAIN_OFFSET := 0x1000
 SECTOR_SIZE := 512
@@ -33,6 +34,10 @@ BM_UTILS := drivers/ports.c.o \
 
 BM_UTILS := $(patsubst %, $(BIN_DIR)/%, $(BM_UTILS))
 
+# Build directories
+HOME_DIR := $(shell echo $$HOME)
+
+
 # Compile
 all: $(BOOT_BIN)
 
@@ -44,16 +49,16 @@ $(MBR_BIN): $(shell find $(MBR_DIR) -name '*.asm')
 # Compile the main boot section
 $(BOOT_BIN_DIR)/$(BM_DIR)/%.o: $(BM_DIR)/%.c
 	@mkdir -p ${shell dirname $@}
-	gcc ${CFLAGS} -c -o $@ $<
+	${CC} ${CFLAGS} -c -o $@ $<
 
 # Link the main boot section
 $(BM_BIN): $(BM_ENTRY) $(filter-out $(BM_ENTRY), $(BM_OBJS))
 	@mkdir -p ${shell dirname $@}
-	ld -m elf_i386 --oformat binary -Ttext=${BOOTMAIN_OFFSET} -o $@ $^ ${BM_UTILS}
+	${LD} -m elf_i386 --oformat binary -Ttext=${BOOTMAIN_OFFSET} -o $@ $^ ${BM_UTILS}
 
 	# [DEBUG]
-	@mkdir -p /home/eylon/Code/os/bin/symbols
-	ld -m elf_i386 -Ttext=${BOOTMAIN_OFFSET} -o /home/eylon/Code/os/bin/symbols/BM.elf $^ ${BM_UTILS}
+	@mkdir -p ${HOME_DIR}/Code/os/bin/symbols
+	${LD} -m elf_i386 -Ttext=${BOOTMAIN_OFFSET} -o ${HOME_DIR}/Code/os/bin/symbols/BM.elf $^ ${BM_UTILS}
 
 # Build the full bootloader disk image
 $(BOOT_BIN): $(MBR_BIN) $(BM_BIN)

--- a/src/libc/makefile
+++ b/src/libc/makefile
@@ -1,8 +1,10 @@
 ## bzlibc Makefile ## ~ eylon
 
 ## Setting ##
-CC	   := gcc
+CC	   ?= gcc
 CFLAGS := -I$(INC_DIR)/libc -ggdb -m32 -nostdlib -nostdinc -fno-builtin -fno-pic -static -ffreestanding -no-pie -Wall -Wextra -Werror
+AR    ?= ar
+RANLIB ?= ranlib
 
 LIB_BIN_DIR := $(BIN_DIR)/libc
 LIB_BIN := $(LIB_BIN_DIR)/lib_bzlibc.a
@@ -21,5 +23,5 @@ $(LIB_BIN_DIR)/%.o: %
 # Link and archive
 $(LIB_BIN): $(LIB_OBJS)
 	@mkdir -p $(shell dirname $@)
-	ar rcs $@ $^
-	ranlib $@
+	${AR} rcs $@ $^
+	${RANLIB} $@

--- a/usr/MakeUser.mk
+++ b/usr/MakeUser.mk
@@ -39,7 +39,7 @@ LIBC := $(BUZZ)/bin/libc/lib_bzlibc.a
 
 # Compiler settings #
 # the C compiler
-CC      := gcc
+CC      ?= gcc
 # compiler flags
 CFLAGS  := -I$(INC_DIR) -I$(BUZZ)/include/libc -m32 -nostdlib -nostartfiles -nostdinc -fno-builtin -static -no-pie -Wall -Wextra -ggdb # -fno-pic
 

--- a/usr/exe/init/makefile
+++ b/usr/exe/init/makefile
@@ -41,7 +41,7 @@ EXEC := $(FS_LAYOUT)/$(shell cat .path)
 LIBC := $(BUZZ)/bin/libc/lib_bzlibc.a
 
 # The C compiler
-CC      := gcc
+CC      ?= gcc
 # Compiler flags
 CFLAGS  := -I$(INC_DIR) -I$(BUZZ)/inc/libc/ -m32 -nostdlib -nostartfiles -nostdinc -fno-builtin -static -no-pie -Wall -Wextra -ggdb # -fno-pic
 

--- a/usr/exe/tester/makefile
+++ b/usr/exe/tester/makefile
@@ -41,7 +41,7 @@ EXEC := $(FS_LAYOUT)/$(shell cat .path)
 LIBC := $(BUZZ)/bin/libc/lib_bzlibc.a
 
 # The C compiler
-CC      := gcc
+CC      ?= gcc
 # Compiler flags
 CFLAGS  := -I$(INC_DIR) -I$(BUZZ)/inc/libc/ -m32 -nostdlib -nostartfiles -nostdinc -fno-builtin -static -no-pie -Wall -Wextra -ggdb # -fno-pic
 


### PR DESCRIPTION
This PR refactors the Makefiles to replace hardcoded definitions of the compiler (`gcc`), linker (`ld`), archiver (`ar`), and ranlib (`ranlib`) with conditional assignments. This change allows users to override these tools via environment variables:
 
 ```
 make CC=i686-elf-gcc AR=i686-elf-ar RANLIB=i686-elf-ranlib LD=i686-elf-ld
 ```
Out of the box, Buzz OS was not buildable for me (`gcc` defaults to clang on Mac OS for example). Since I'm on arm64, I had to use a cross compiler.

2. Also in this PR is using the user's home directory instead of `/home/eylon/` 
3. This may have been a separate PR, but `makefile` now creates `USR_FILES_DIR`(usr/file) by default when building the filesystem image. Previously, the build would fail when this directory didn't exist.
 
 
 It appears you prefer to use curly brackets {} for variable assignments instead of regular parenthesis so I tried to keep the same style.